### PR TITLE
 Remove Travis build status from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Apache Fineract CN Payroll [![Build Status](https://api.travis-ci.com/apache/fineract-cn-payroll.svg?branch=develop)](https://travis-ci.com/apache/fineract-cn-payroll) [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-payroll)](https://hub.docker.com/r/apache/fineract-cn-payroll/builds)
+# Apache Fineract CN Payroll [![Docker Cloud Build Status](https://img.shields.io/docker/cloud/build/apache/fineract-cn-payroll)](https://hub.docker.com/r/apache/fineract-cn-payroll/builds)
 
 This project provides functionality to configure payroll allocations and distribute payroll payments for customers.
 [Read more](https://cwiki.apache.org/confluence/display/FINERACT/Fineract+CN+Project+Structure#FineractCNProjectStructure-payroll).


### PR DESCRIPTION
Due to the removal of the Travis build scripts from the project. The build status in the README.md is now misleading and needs to be removed.